### PR TITLE
:bug: Prevent Sentinel from being targeted by biters

### DIFF
--- a/prototypes/sentinel.lua
+++ b/prototypes/sentinel.lua
@@ -72,5 +72,6 @@ data:extend({
     },
     radius_minimap_visualisation_color = { r = 0.059, g = 0.092, b = 0.235, a = 0.275 },
     rotation_speed = 0.0015,
+    is_military_target = false,
   },
 })


### PR DESCRIPTION
## Summary
Set `is_military_target = false` on Sentinel entity so biters no longer prioritize it as an attack target, matching the behavior of the base game radar and K2 Advanced Radar.

## Changes
- Add `is_military_target = false` to Sentinel prototype definition

## Test Plan
- Place a Sentinel near biter nests and verify biters do not prioritize attacking it

Fixes #10
