### PR TITLE
:sparkles: Add startup setting to toggle radar stat enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A standalone Factorio 2.0 MOD that brings the Sentinel entity from [Krastorio2](
 
 - **Sentinel** — a 1x1 compact radar that monitors 1 nearby chunk with low power consumption
 - **Technology tree restructuring** — lamp → sentinel → radar progression; radar is pushed back to the chemical science pack era
-- **Radar enhancement** — vanilla radar is buffed at the cost of higher power consumption, creating a clear role separation from the sentinel
+- **Radar enhancement** — vanilla radar is buffed at the cost of higher power consumption, creating a clear role separation from the sentinel (can be disabled via startup setting)
 - **Achievement** — "Big brother is watching you" for building 100 sentinels
 
 ## Technology Tree

--- a/locale/en/k2-sentinel.cfg
+++ b/locale/en/k2-sentinel.cfg
@@ -24,3 +24,9 @@ kr-big-brother-is-watching-you=Big brother is watching you
 
 [achievement-description]
 kr-big-brother-is-watching-you=Build 100 sentinels.
+
+[mod-setting-name]
+k2-sentinel-enhance-radar=Enhance radar
+
+[mod-setting-description]
+k2-sentinel-enhance-radar=When enabled, the radar is buffed in the same way as in Krastorio 2 (more HP, higher power consumption, greater scan range).

--- a/locale/ja/k2-sentinel.cfg
+++ b/locale/ja/k2-sentinel.cfg
@@ -18,3 +18,9 @@ kr-big-brother-is-watching-you=ビッグ・ブラザー様がみてる
 
 [achievement-description]
 kr-big-brother-is-watching-you=センチネルを100体設置する。
+
+[mod-setting-name]
+k2-sentinel-enhance-radar=レーダーを強化する
+
+[mod-setting-description]
+k2-sentinel-enhance-radar=有効にすると、レーダーがKrastorio 2と同様に強化されます (HP増加・消費電力増加・スキャン範囲拡大)。

--- a/prototypes/radar-updates.lua
+++ b/prototypes/radar-updates.lua
@@ -1,8 +1,10 @@
-data.raw.radar["radar"].max_health = 300
-data.raw.radar["radar"].energy_usage = "1MW"
-data.raw.radar["radar"].max_distance_of_nearby_sector_revealed = 5
-data.raw.radar["radar"].max_distance_of_sector_revealed = 16
-data.raw.radar["radar"].energy_per_sector = "2MJ"
+if settings.startup["k2-sentinel-enhance-radar"].value then
+  data.raw.radar["radar"].max_health = 300
+  data.raw.radar["radar"].energy_usage = "1MW"
+  data.raw.radar["radar"].max_distance_of_nearby_sector_revealed = 5
+  data.raw.radar["radar"].max_distance_of_sector_revealed = 16
+  data.raw.radar["radar"].energy_per_sector = "2MJ"
+end
 
 data.raw.recipe["radar"].ingredients = {
   { type = "item", name = "kr-sentinel", amount = 1 },

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,8 @@
+data:extend({
+  {
+    type = "bool-setting",
+    name = "k2-sentinel-enhance-radar",
+    setting_type = "startup",
+    default_value = true,
+  }
+})


### PR DESCRIPTION
## Summary

Add a `k2-sentinel-enhance-radar` startup setting (default: `true`) to allow players to opt out of the vanilla radar stat enhancement.

## Changes

- Add `settings.lua` with a boolean startup setting
- Wrap radar stat modifications in `prototypes/radar-updates.lua` with a conditional; recipe and technology changes remain unconditional
- Add EN/JA locale entries for the setting name and description
- Note the option in README

Closes #14
